### PR TITLE
Allow multiple bundle instances to be added to the kernel

### DIFF
--- a/src/InteropServiceProviderBridgeBundle.php
+++ b/src/InteropServiceProviderBridgeBundle.php
@@ -25,6 +25,8 @@ class InteropServiceProviderBridgeBundle extends Bundle implements RegistryProvi
         $this->serviceProviders = $serviceProviders;
         $this->useDiscovery = $useDiscovery;
         $this->id = self::$count;
+        $this->name = $this->getName() . $this->id;
+
         self::$count++;
     }
 
@@ -40,6 +42,16 @@ class InteropServiceProviderBridgeBundle extends Bundle implements RegistryProvi
     {
         $registryServiceName = 'service_provider_registry_'.$this->id;
         $this->container->set($registryServiceName, $this->getRegistry($this->container));
+    }
+
+    /**
+     * When the Kernel shuts down, this bundle's static identifier must be
+     * reset, otherwise it may lead to incorrect identifier binding for the
+     * compiled container.
+     */
+    public function shutdown()
+    {
+        self::$count = 0;
     }
 
     /**


### PR DESCRIPTION
This commit applies two things:

- The name of the bundle is dynamically changed, because Symfony's
  kernel doesn't allow multiple bundles with the same name
- When the kernel is shutdown, the bundles must be shutdown as well,
  meaning the static identifier must be reset.

One of the known effects before this change was seen when clearing
caches: the kernel could be booted several times during the same
runtime, meaning that the static identifier would change for identical
bundle instances and therefore lead to confusion for the compiled
container, which would not be able to fetch the correct instance.