### PR TITLE
Call extension method in registry

### DIFF
--- a/src/ServiceProviderCompilationPass.php
+++ b/src/ServiceProviderCompilationPass.php
@@ -95,7 +95,7 @@ class ServiceProviderCompilationPass implements CompilerPassInterface
     }
 
     private function extendService($serviceName, $serviceProviderKey, $callable, ContainerBuilder $container) {
-        $factoryDefinition = $this->getServiceDefinitionFromCallable($serviceName, $serviceProviderKey, $callable);
+        $factoryDefinition = $this->getServiceDefinitionFromCallable($serviceName, $serviceProviderKey, $callable, true);
 
         if (!$container->has($serviceName)) {
             $container->setDefinition($serviceName, $factoryDefinition);
@@ -129,7 +129,7 @@ class ServiceProviderCompilationPass implements CompilerPassInterface
         return $serviceName.'_decorated_'.$counter;
     }
 
-    private function getServiceDefinitionFromCallable($serviceName, $serviceProviderKey, callable $callable)
+    private function getServiceDefinitionFromCallable($serviceName, $serviceProviderKey, callable $callable, $isExtension = false)
     {
         /*if ($callable instanceof DefinitionInterface) {
             // TODO: plug the definition-interop converter here!
@@ -141,7 +141,8 @@ class ServiceProviderCompilationPass implements CompilerPassInterface
             $factoryDefinition->setFactory($callable);
             $factoryDefinition->addArgument(new Reference('interop_service_provider_acclimated_container'));
         } else {
-            $factoryDefinition->setFactory([ new Reference('service_provider_registry_'.$this->registryId), 'createService' ]);
+            $method = $isExtension ? 'extendService' : 'createService';
+            $factoryDefinition->setFactory([ new Reference('service_provider_registry_'.$this->registryId), $method ]);
             $factoryDefinition->addArgument($serviceProviderKey);
             $factoryDefinition->addArgument($serviceName);
             $factoryDefinition->addArgument($containerDefinition);

--- a/src/Tests/Fixtures/TestServiceProvider.php
+++ b/src/Tests/Fixtures/TestServiceProvider.php
@@ -35,6 +35,10 @@ class TestServiceProvider implements ServiceProviderInterface
 
     public function getExtensions()
     {
-        return [];
+        return [
+            'stringValue' => function (ContainerInterface $container, $value) {
+                return $value . '1';
+            },
+        ];
     }
 }

--- a/src/Tests/Fixtures/TestServiceProviderOverride.php
+++ b/src/Tests/Fixtures/TestServiceProviderOverride.php
@@ -8,7 +8,9 @@ class TestServiceProviderOverride implements ServiceProviderInterface
 {
     public function getFactories()
     {
-        return [];
+        return [
+            'stringValue' => function () { return 'foo'; },
+        ];
     }
 
     public static function overrideServiceA(ContainerInterface $container, \stdClass $serviceA = null)
@@ -20,7 +22,10 @@ class TestServiceProviderOverride implements ServiceProviderInterface
     public function getExtensions()
     {
         return [
-            'serviceA' => [ TestServiceProviderOverride::class, 'overrideServiceA' ]
+            'serviceA' => [ TestServiceProviderOverride::class, 'overrideServiceA' ],
+            'stringValue' => function (ContainerInterface $container, $value) {
+                return $value . '2';
+            },
         ];
     }
 }

--- a/tests/ServiceProviderCompilationPassTest.php
+++ b/tests/ServiceProviderCompilationPassTest.php
@@ -56,6 +56,18 @@ class ServiceProviderCompilationPassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $serviceA->newProperty2);
     }
 
+    public function testExtensionsAreCalledInCorrectOrder()
+    {
+        $container = $this->getContainer([
+            new TestServiceProvider(),
+            new TestServiceProviderOverride(),
+        ]);
+
+        $value = $container->get('stringValue');
+
+        $this->assertSame('foo12', $value);
+    }
+
     /**
      * @expectedException \TheCodingMachine\Interop\ServiceProviderBridgeBundle\Exception\InvalidArgumentException
      */


### PR DESCRIPTION
The definition given to Symfony container would always call the method
which creates a service in the registry. It led to unexpected behaviours
that could not be perceived in current tests because the extension
factories don't return a different value.